### PR TITLE
Fix CaseCategory for cases opened in Lightbox

### DIFF
--- a/fogbugz-extended.user.js
+++ b/fogbugz-extended.user.js
@@ -138,7 +138,7 @@
             parentElem.prepend("<hr id='divider' style='margin-left: 8px !important;'/>");
         }
 
-        var caseCategory = $(".case-category").attr("title");
+        var caseCategory = $(".case * .case-category").attr("title");
 
         if(!caseCategory) {
             return;


### PR DESCRIPTION
When a case is opened in the lightbox, the `.case-category` selector matches the first case in the background.

The new selector supports cases opened in a lightbox or directly